### PR TITLE
Also allow key version 4009, which seems to be the same.

### DIFF
--- a/Converter.cs
+++ b/Converter.cs
@@ -1351,7 +1351,8 @@ namespace FbxSharp
                     var defaultValue = ((Number)prop.Values[0]).AsDouble.Value;
                     break;
                 case "KeyVer":
-                    if (((Number)prop.Values[0]).AsLong.Value != 4008)
+                    long keyVersion = ((Number)prop.Values[0]).AsLong.Value;
+                    if (keyVersion != 4008 && keyVersion != 4009)
                         throw new NotImplementedException();
                     break;
                 case "KeyTime":


### PR DESCRIPTION
This PR allows key version 4009, which is what is produced by the FBX SDK version 2017.1 on Linux.