### PR TITLE
Number tests

### DIFF
--- a/FbxSharpTests/FbxSharpTests.csproj
+++ b/FbxSharpTests/FbxSharpTests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="CameraTest.cs" />
     <Compile Include="CollectorTest.cs" />
     <Compile Include="ObjectPrinterTest.cs" />
+    <Compile Include="NumberTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/FbxSharpTests/NumberTest.cs
+++ b/FbxSharpTests/NumberTest.cs
@@ -1,0 +1,23 @@
+using System;
+using NUnit.Framework;
+using FbxSharp;
+
+namespace FbxSharpTests
+{
+    [TestFixture]
+    public class NumberTest : TestBase
+    {
+        [Test]
+        public void Create_ValuesAreNull()
+        {
+            // when:
+	    var n = new Number();
+
+            // then:
+	    Assert.IsNull(n.AsDouble);
+	    Assert.IsNull(n.AsLong);
+	    Assert.IsNull(n.StringRepresentation);
+	    // Assert.AreEqual("null", n.ToString());
+        }
+    }
+}

--- a/FbxSharpTests/NumberTest.cs
+++ b/FbxSharpTests/NumberTest.cs
@@ -19,5 +19,66 @@ namespace FbxSharpTests
 	    Assert.IsNull(n.StringRepresentation);
 	    // Assert.AreEqual("null", n.ToString());
         }
+
+	[Test]
+	public void CreateWithLong_HasLongAndDoubleValue()
+	{
+	    // when
+	    var n = new Number("123");
+
+	    // then
+	    Assert.IsTrue(n.AsDouble.HasValue);
+	    Assert.AreEqual(123d, n.AsDouble.Value);
+	    Assert.IsTrue(n.AsLong.HasValue);
+	    Assert.AreEqual(123, n.AsLong.Value);
+	    Assert.AreEqual("123", n.ToString());
+	    Assert.AreEqual("123", n.StringRepresentation);
+
+	    // when
+	    n = new Number("12345678900");
+
+	    // then
+	    Assert.IsTrue(n.AsDouble.HasValue);
+	    Assert.AreEqual(12345678900d, n.AsDouble.Value);
+	    Assert.IsTrue(n.AsLong.HasValue);
+	    Assert.AreEqual(12345678900, n.AsLong.Value);
+	    Assert.AreEqual("12345678900", n.ToString());
+	    Assert.AreEqual("12345678900", n.StringRepresentation);
+
+	    // when
+	    n = new Number("0");
+
+	    // then
+	    Assert.IsTrue(n.AsDouble.HasValue);
+	    Assert.AreEqual(0d, n.AsDouble.Value);
+	    Assert.IsTrue(n.AsLong.HasValue);
+	    Assert.AreEqual(0L, n.AsLong.Value);
+	    Assert.AreEqual("0", n.ToString());
+	    Assert.AreEqual("0", n.StringRepresentation);
+	}
+
+	[Test]
+	public void CreateWithDouble_HasOnlyDoubleValue()
+	{
+	    // when
+	    var n = new Number("0.0");
+
+	    // then
+	    Assert.IsTrue(n.AsDouble.HasValue);
+	    Assert.AreEqual(0d, n.AsDouble.Value);
+	    Assert.IsFalse(n.AsLong.HasValue);
+	    Assert.AreEqual("0", n.ToString());
+	    Assert.AreEqual("0.0", n.StringRepresentation);
+
+	    // when
+	    n = new Number("0.000000000000000");
+
+	    // then
+	    Assert.IsTrue(n.AsDouble.HasValue);
+	    Assert.AreEqual(0d, n.AsDouble.Value);
+	    Assert.IsFalse(n.AsLong.HasValue);
+	    Assert.AreEqual("0", n.ToString());
+	    Assert.AreEqual("0.000000000000000", n.StringRepresentation);
+	}
     }
 }

--- a/Number.cs
+++ b/Number.cs
@@ -25,7 +25,7 @@ namespace FbxSharp
 
             if (!AsLong.HasValue && !AsDouble.HasValue)
             {
-                throw new ArgumentException("The string cannot be interpreted as a snumber", "str");
+                throw new ArgumentException("The string cannot be interpreted as a number", "str");
             }
         }
 


### PR DESCRIPTION
This PR adds a few tests for the `Number` value type. In particular it tests that `"0.000000000000000"` gets parsed correctly as a `double`.

Fixes #39 