### PR TITLE
Better exceptions 2

### DIFF
--- a/ConversionException.cs
+++ b/ConversionException.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace FbxSharp
+{
+    public class ConversionException : Exception
+    {
+        public ConversionException(InputLocation location, string message)
+            : this(FormatMessage(location, message))
+        {
+        }
+
+        public ConversionException(InputLocation location, string message, Exception inner)
+            : this(FormatMessage(location, message), inner)
+        {
+        }
+
+        static string FormatMessage(InputLocation location, string message)
+        {
+            return string.Format("at {0}:{1},{2}: {3}", location.Filename, location.Line, location.Column, message);
+        }
+
+        public ConversionException(string message)
+            : base(message)
+        {
+        }
+
+        public ConversionException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/Converter.cs
+++ b/Converter.cs
@@ -64,7 +64,7 @@ namespace FbxSharp
                     dstProp.ConnectSrcObject(fbxObjectsById[srcId]);
                     break;
                 default:
-                    throw new InvalidOperationException(string.Format("Unknown connection type: {0}", connType));
+                    throw new InvalidOperationException(string.Format("Unknown connection type. Expected 'OO' or 'OP'. Got '{0}' instead.", connType));
                 }
             }
 
@@ -104,12 +104,12 @@ namespace FbxSharp
         void CheckDocuments(ParseObject docs)
         {
             if (docs.Properties[0].Name != "Count")
-                throw new NotImplementedException();
+                throw new NotImplementedException("Properties list does not start with 'Count'.");
             if (docs.Properties[0].Values.Count < 1)
-                throw new NotImplementedException();
+                throw new NotImplementedException("Property 'Count' has no value.");
             var count = ((Number)docs.Properties[0].Values[0]).AsLong.Value;
             if (docs.Properties.Count != count + 1)
-                throw new NotImplementedException();
+                throw new NotImplementedException("Properties list Count does not match actual number of properties.");
         }
 
         void CheckDocument(ParseObject doc)
@@ -119,19 +119,19 @@ namespace FbxSharp
         void CheckDefinitions(ParseObject defs)
         {
             if (defs.Properties[0].Name != "Version")
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Properties list does not start with 'Version'. Got '{0}' instead.", defs.Properties[0].Name));
             if (defs.Properties[0].Values.Count < 1)
-                throw new NotImplementedException();
+                throw new NotImplementedException("Property 'Version' has no value.");
             var version = ((Number)defs.Properties[0].Values[0]).AsLong.Value;
 
             if (defs.Properties[1].Name != "Count")
-                throw new NotImplementedException();
+                throw new NotImplementedException("Properties list does not have a 'Count' in the second place.");
             if (defs.Properties[1].Values.Count < 1)
-                throw new NotImplementedException();
+                throw new NotImplementedException("Property 'Count' has no value.");
             var count = ((Number)defs.Properties[1].Values[0]).AsLong.Value;
 
 //            if (defs.Properties.Count != count + 2)
-//                throw new NotImplementedException();
+//                throw new NotImplementedException("Explicit count does not match actual number of properties.");
         }
 
         Dictionary<string, Func<ParseObject, FbxObject>> ConvertersByObjectName =
@@ -211,7 +211,10 @@ namespace FbxSharp
                 return ConvertCamera(obj);
             }
 
-            throw new NotImplementedException();
+            throw new NotImplementedException(
+                string.Format(
+                    "Unknown FBXNodeAttribute type: '{0}'.",
+                    typeFlags));
         }
 
         public static FbxSkeleton ConvertSkeleton(ParseObject obj)
@@ -226,7 +229,7 @@ namespace FbxSharp
                 foreach (var p in props70.Properties)
                 {
                     if (p.Name != "P") 
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Incorrect name for a property list: '{0}'.", p.Name));
 
                     //P: "Size", "double", "Number", "",0.988142713904381
                     var propName = ((string)p.Values[0]);
@@ -240,7 +243,7 @@ namespace FbxSharp
                     }
                     else
                     {
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Unknown property type. Expected 'double'. Got '{0}' instead.", type1));
                     }
 
                     switch (propName)
@@ -249,7 +252,7 @@ namespace FbxSharp
                         skeleton.Size.Value = (double)value;
                         break;
                     default:
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Unknown property name. Expected 'Size'. Got '{0}' instead.", propName));
                     }
                 }
             }
@@ -279,14 +282,15 @@ namespace FbxSharp
                     break;
                 case "TypeFlags":
                     if (((string)prop.Values[0]) != "Light")
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Unknown type in FbxLight. Expected 'Light'. Got '{0}' instead.", prop.Values[0]));
                     break;
                 case "GeometryVersion":
-                    if (((Number)prop.Values[0]).AsLong.Value != 124)
-                        throw new NotImplementedException();
+                    var gversion = ((Number)prop.Values[0]).AsLong.Value;
+                    if (gversion != 124)
+                        throw new NotImplementedException(string.Format("Unknown geometry version in FbxLight. Expected '124'. Got '{0}' instead.", gversion));
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property name in FbxLight. Expected 'Properties70', 'TypeFlags', or 'GeometryVersion'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -315,11 +319,11 @@ namespace FbxSharp
                     break;
                 case "TypeFlags":
                     if (((string)prop.Values[0]) != "Camera")
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Incorrect type in FbxCamera. Expected 'Camera'. Got '{0}' instead.", (string)prop.Values[0]));
                     break;
                 case "GeometryVersion":
                     if (((Number)prop.Values[0]).AsLong.Value != 124)
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Unknown geometry version in FbxCamera. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
                     break;
                 case "Position":
                     position = new FbxVector3(
@@ -355,7 +359,7 @@ namespace FbxSharp
                     cameraOrthoZoom = ((Number)prop.Values[0]).AsDouble.Value;
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property name in FbxCamera. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -371,7 +375,7 @@ namespace FbxSharp
             case "Mesh":
                 return ConvertMesh(obj);
             default:
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Unknown geometry type in FbxGeometry. Expected 'Mesh'. Got '{0}' instead.", geometryType));
             }
         }
 
@@ -412,7 +416,7 @@ namespace FbxSharp
                     break;
                 case "GeometryVersion":
                     if (((Number)prop.Values[0]).AsLong.Value != 124)
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Unknown geometry version in FbxMesh. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
                     break;
                 case "LayerElementNormal":
                     index = (int)(prop.Values.Count > 0 ? ((Number)prop.Values[0]).AsLong.Value : 0);
@@ -439,7 +443,7 @@ namespace FbxSharp
                     ConvertLayer(layer, prop, normals, uvs, visibility, materials);
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property name in FbxMesh. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -454,17 +458,18 @@ namespace FbxSharp
                 {
                 case "Version":
                     if (prop.Values.Count < 0)
-                        throw new NotImplementedException();
-                    if (((Number)prop.Values[0]).AsLong.Value != 100)
-                        throw new NotImplementedException();
+                        throw new NotImplementedException("No value for 'Version' in FbxLayer.");
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 100)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayer. Expected '100'. Got '{0}' instead.", version));
                     break;
                 case "LayerElement":
                     var type = prop.FindPropertyByName("Type");
                     if (type == null)
-                        throw new NotImplementedException();
+                        throw new NotImplementedException("No Type found in FbxLayer.");
                     var index = prop.FindPropertyByName("TypedIndex");
                     if (index == null)
-                        throw new NotImplementedException();
+                        throw new NotImplementedException("No TypedIndex found in FbxLayer.");
                     var indexValue = (int)((Number)index.Values[0]).AsLong.Value;
                     switch ((string)type.Values[0])
                     {
@@ -481,11 +486,11 @@ namespace FbxSharp
                         layer.SetUVs(uvs[indexValue]);
                         break;
                     default:
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Unknown LayerElement type in FbxLayer. Expected 'LayerElementNormal', 'LayerElementMaterial', 'LayerElementVisibility', or 'LayerElementUV'. Got '{0}' instead.", (string)type.Values[0]));
                     }
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxLayer. Expected 'Version' or 'LayerElement'. Got '{0}' instead.", prop.Name));
                 }
             }
         }
@@ -499,8 +504,9 @@ namespace FbxSharp
                 switch (prop.Name)
                 {
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 101)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 101)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayerElementNormal. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     normals.SetName((string)prop.Values[0]);
@@ -519,7 +525,7 @@ namespace FbxSharp
                         .Select(v => v.ToVector4()));
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxLayerElementNormal. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Normals'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -535,8 +541,9 @@ namespace FbxSharp
                 switch (prop.Name)
                 {
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 101)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 101)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayerElementUV. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     uvs.Name = ((string)prop.Values[0]);
@@ -559,7 +566,7 @@ namespace FbxSharp
                         .Select(n => (int)((Number)n).AsLong.Value));
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxLayerElementUV. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', 'UV', or 'UVIndex'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -575,8 +582,9 @@ namespace FbxSharp
                 switch (prop.Name)
                 {
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 101)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 101)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayerElementVisibility. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     visibility.Name = ((string)prop.Values[0]);
@@ -591,7 +599,7 @@ namespace FbxSharp
                     visibility.GetDirectArray().List.AddRange(prop.Properties[0].Values.Select(n => (((Number)n).AsLong.Value == 1)));
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxLayerElementVisibility. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Visibility'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -607,8 +615,9 @@ namespace FbxSharp
                 switch (prop.Name)
                 {
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 101)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 101)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayerElementMaterial. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     material.Name = ((string)prop.Values[0]);
@@ -624,7 +633,7 @@ namespace FbxSharp
                         prop.Properties[0].Values.Select(n => (int)((Number)n).AsLong.Value));
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxLayerElementMaterial. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Materials'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -634,7 +643,7 @@ namespace FbxSharp
         public static FbxLayerElement.EMappingMode ConvertMappingInformationType(ParseObject obj)
         {
             if (obj.Values.Count < 1)
-                throw new NotImplementedException();
+                throw new NotImplementedException("Mapping mode has no value.");
             switch ((string)obj.Values[0])
             {
             case "ByPolygonVertex":
@@ -648,14 +657,14 @@ namespace FbxSharp
             case "AllSame":
                 return FbxLayerElement.EMappingMode.AllSame;
             default:
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Unknown mapping mode. Expected 'ByPolygonVertex', 'ByPolygon', 'ByVertex', 'ByEdge', or 'AllSame'. Got '{0}' instead.", (string)obj.Values[0]));
             }
         }
 
         public static FbxLayerElement.EReferenceMode ConvertReferenceInformationType(ParseObject obj)
         {
             if (obj.Values.Count < 1)
-                throw new NotImplementedException();
+                throw new NotImplementedException("Reference mode has no value.");
             switch ((string)obj.Values[0])
             {
             case "Direct":
@@ -663,7 +672,7 @@ namespace FbxSharp
             case "IndexToDirect":
                 return FbxLayerElement.EReferenceMode.IndexToDirect;
             default:
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Unknown reference mode. Expected 'Direct' or 'IndexToDirect'. Got '{0}' instead.", (string)obj.Values[0]));
             }
         }
 
@@ -674,7 +683,7 @@ namespace FbxSharp
             foreach (var p in props70.Properties)
             {
                 if (p.Name != "P")
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Incorrect property name. Expected 'P'. Got '{0}' instead.", p.Name));
 
                 // P: "Color", "ColorRGB", "Color", "",0.0313725490196078,0.0313725490196078,0.0313725490196078
                 var propName = ((string)p.Values[0]);
@@ -725,7 +734,7 @@ namespace FbxSharp
                     y = ((Number)p.Values[5]).AsDouble.Value;
                     z = ((Number)p.Values[6]).AsDouble.Value;
                     if (comment != "A+" && comment != "A")
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Invalid indicator for Lcl Scaling. Expected 'A' or 'A+'. Got '{0}' instead.", comment));
                     propValue = new FbxVector3(x, y, z);
                     break;
                 case "KString":
@@ -748,8 +757,8 @@ namespace FbxSharp
                     propValue = "";
                     break;
                 case "Number":
-                    if ((string)p.Values[3] != "A")
-                        throw new InvalidOperationException();
+                    if (comment != "A")
+                        throw new NotImplementedException(string.Format("Invalid indicator for Number. Expected 'A'. Got '{0}' instead.", comment));
                     propType = typeof(double);
                     propValue = ((Number)p.Values[4]).AsDouble.Value;
                     break;
@@ -809,9 +818,9 @@ namespace FbxSharp
             var node = new FbxNode();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
             node.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -820,8 +829,9 @@ namespace FbxSharp
                 switch (prop.Name)
                 {
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 232)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 232)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxNode. Expected '232'. Got '{0}' instead.", version));
                     break;
                 case "Properties70":
                     ImportProperties(node, ConvertProperties70(prop));
@@ -839,7 +849,7 @@ namespace FbxSharp
                     node.Culling = (string)prop.Values[0];
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxNode. Expected 'Version', 'Properties70', 'MultiLayer', 'MultiTake', 'Shading', or 'Culling'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -877,9 +887,9 @@ namespace FbxSharp
             var pose = new FbxPose();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
             pose.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -896,12 +906,13 @@ namespace FbxSharp
                     }
                     else
                     {
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Unknown pose type. Expected 'BindPose'. Got '{0}' instead.", (string)prop.Values[0]));
                     }
                     break;
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 100)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 100)
+                        throw new NotImplementedException(string.Format("Unknown version. Expected 100. Got {0} instead.", version));
                     break;
                 case "NbPoseNodes":
                     numPoseNodes = ((Number)prop.Values[0]).AsLong.Value;
@@ -911,12 +922,12 @@ namespace FbxSharp
                     pose.Add(posenode.Item1, posenode.Item2, posenode.Item3);
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxPose. Expected 'Type', 'Version', 'NbPoseNodes', or 'PoseNode'. Got '{0}' instead.", prop.Name));
                 }
             }
 
             if (numPoseNodes != pose.GetCount())
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("The number of pose objects ({0}) does not match the value explicit given ({1}).", pose.GetCount(), numPoseNodes));
 
             return pose;
         }
@@ -927,18 +938,18 @@ namespace FbxSharp
             Dictionary<ulong, ulong> actualIdsByInFileIds)
         {
             if (obj.Properties.Count != 2)
-                throw new NotImplementedException();
+                throw new NotImplementedException("Unknown properties in PoseNode.");
 
             var nodeIdProp = obj.FindPropertyByName("Node");
             if (nodeIdProp == null)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("No node ID found in PoseNode.");
             var inFileNodeId = (ulong)((Number)nodeIdProp.Values[0]).AsLong.Value;
             var nodeId = actualIdsByInFileIds[inFileNodeId];
             var node = (FbxNode)fbxObjectsById[(ulong)nodeId];
 
             var matrixProp = obj.FindPropertyByName("Matrix");
             if (matrixProp == null)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("No matrix found in PoseNode.");
             var matrix = ConvertMatrix(matrixProp);
 
             return new Tuple<FbxNode, FbxMatrix, bool>(node, matrix, false);
@@ -947,10 +958,10 @@ namespace FbxSharp
         public static FbxMatrix ConvertMatrix(ParseObject obj)
         {
             if (obj.Properties.Count != 1)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("Unknown properties in FbxMatrix.");
             var values = obj.Properties[0].Values;
             if (values.Count != 16)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Incorrect number of values for FbxMatrix. Expected 16. Got {0} instead.", values.Count));
 
             var v = values.Select(n => ((Number)n).AsDouble.Value).ToArray();
 
@@ -966,11 +977,11 @@ namespace FbxSharp
         {
             var shadingModelProp = obj.FindPropertyByName("ShadingModel");
             if (shadingModelProp == null)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("No shading model found in FbxSurfaceMaterial.");
 
             var shadingModel = (string)shadingModelProp.Values[0];
             if (shadingModel != "phong")
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Unknown shading model in FbxSurfaceMaterial. Expected 'phong'. Got '{0}' instead.", shadingModel));
 
             return ConvertPhongMaterial(obj);
         }
@@ -980,9 +991,9 @@ namespace FbxSharp
             var material = new FbxSurfacePhong();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
             material.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -991,8 +1002,9 @@ namespace FbxSharp
                 switch (prop.Name)
                 {
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 102)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 102)
+                        throw new NotImplementedException(string.Format("Unknown version. Expected 102. Got {0} instead.", version));
                     break;
                 case "ShadingModel":
                     break;
@@ -1004,7 +1016,7 @@ namespace FbxSharp
                     ImportProperties(material, ConvertProperties70(prop));
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxSurfacePhong.  Expected 'Version', 'ShadingModel', 'MultiLayer', or 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1014,9 +1026,9 @@ namespace FbxSharp
         public static FbxObject ConvertDeformer(ParseObject obj)
         {
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in deformer. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for deformer. Expected 3. Got {0} instead.", obj.Values.Count));
             var type = ((string)obj.Values[2]);
 
             switch (type)
@@ -1026,7 +1038,7 @@ namespace FbxSharp
             case "Cluster":
                 return ConvertCluster(obj);
             default:
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Unknown deformer type. Expected 'Skin' or 'Cluster'. Got '{0}' instead.", type));
             }
         }
 
@@ -1035,9 +1047,9 @@ namespace FbxSharp
             var skin = new FbxSkin();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
             skin.Name = ((string)obj.Values[1]);
 
             foreach (var prop in obj.Properties)
@@ -1045,15 +1057,16 @@ namespace FbxSharp
                 switch (prop.Name)
                 {
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 101)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 101)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxSkin. Expected '101'. Got '{0}' instead.", version));
                     break;
-                case "Link_DeformAcuracy":
+                case "Link_DeformAcuracy":  // TODO: double-check spelling
                     var accuracy = ((Number)prop.Values[0]).AsDouble.Value;
                     skin.DeformAccuracy = accuracy;
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxSkin. Expected 'Version' or 'Link_DeformAcuracy. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1065,9 +1078,9 @@ namespace FbxSharp
             var cluster = new FbxCluster();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
             cluster.Name = ((string)obj.Values[1]);
 
             bool hasIndexes = false;
@@ -1080,8 +1093,9 @@ namespace FbxSharp
                 switch (prop.Name)
                 {
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 100)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 100)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxSkin. Expected '100'. Got '{0}' instead.", version));
                     break;
                 case "UserData":
                     break;
@@ -1104,7 +1118,7 @@ namespace FbxSharp
                     hasTransformLink = true;
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxCluster. Expected 'Version', 'UserData', 'Indexes', 'Weights', 'Transform', or 'TransformLink'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1116,9 +1130,9 @@ namespace FbxSharp
             var video = new FbxVideo();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
             video.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1142,7 +1156,8 @@ namespace FbxSharp
                     video.RelativeFilename = (string)prop.Values[0];
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxVideo. Expected 'Type', 'Properties70', 'UseMipMap', 'Filename', or 'RelativeFilename'. Got '{0}' instead.", prop.Name));
+
                 }
             }
 
@@ -1154,9 +1169,9 @@ namespace FbxSharp
             var texture = new FbxTexture();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
             texture.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1168,13 +1183,14 @@ namespace FbxSharp
                     texture.Type = (string)prop.Values[0];
                     break;
                 case "Version":
-                    if (((Number)prop.Values[0]).AsLong.Value != 202)
-                        throw new NotImplementedException();
+                    var version = ((Number)prop.Values[0]).AsLong.Value;
+                    if (version != 202)
+                        throw new NotImplementedException(string.Format("Unknown Version in FbxTexture. Expected '202'. Got '{0}' instead.", version));
                     break;
                 case "TextureName":
                     var name = (string)prop.Values[0];
                     if (name != texture.Name)
-                        throw new InvalidOperationException();
+                        throw new InvalidOperationException(string.Format("TextureName does not match. Expected '{0}'. Got '{1}' instead.", texture.Name, name));
                     break;
                 case "Properties70":
                     ImportProperties(texture, ConvertProperties70(prop));
@@ -1202,7 +1218,7 @@ namespace FbxSharp
                     texture.Cropping = ConvertVector4(prop.Values);
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxTexture: '{0}'.", prop.Name));
                 }
             }
 
@@ -1241,9 +1257,9 @@ namespace FbxSharp
             var animstack = new FbxAnimStack();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
             animstack.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1255,7 +1271,7 @@ namespace FbxSharp
                     ImportProperties(animstack, ConvertProperties70(prop));
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxAnimStack. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1267,14 +1283,14 @@ namespace FbxSharp
             var animlayer = new FbxAnimLayer();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
             animlayer.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
             if (obj.Properties.Count > 0)
-                throw new NotImplementedException();
+                throw new NotImplementedException("Expected property list to be empty.");
 
             return animlayer;
         }
@@ -1284,9 +1300,9 @@ namespace FbxSharp
             var animCurveNode = new FbxAnimCurveNode();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
             animCurveNode.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1319,7 +1335,7 @@ namespace FbxSharp
                     }
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxAnimCurveNode. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1331,9 +1347,9 @@ namespace FbxSharp
             var curve = new FbxAnimCurve();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format("Not enough values in FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException();
+                throw new NotImplementedException(string.Format("Too many values for FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
             curve.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1353,7 +1369,7 @@ namespace FbxSharp
                 case "KeyVer":
                     long keyVersion = ((Number)prop.Values[0]).AsLong.Value;
                     if (keyVersion != 4008 && keyVersion != 4009)
-                        throw new NotImplementedException();
+                        throw new NotImplementedException(string.Format("Unknown KeyVer. Expected 4008 or 4009. Got {0} instead.", keyVersion));
                     break;
                 case "KeyTime":
                     keyTimes = prop.Properties[0].Values.Select(n => ((Number)n).AsLong.Value).ToArray();
@@ -1371,7 +1387,7 @@ namespace FbxSharp
                     attrRefCounts = prop.Properties[0].Values.Select(n => ((Number)n).AsLong.Value).ToArray();
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(string.Format("Unknown property in FbxAnimCurve. Expected 'Default', 'KeyVer', 'KeyTime', 'KeyValueFloat', 'KeyAttrFlags', 'KeyAttrDataFloat', or 'KeyAttrRefCount'. Got '{0}' instead.", prop.Name));
                 }
             }
 

--- a/Converter.cs
+++ b/Converter.cs
@@ -64,7 +64,7 @@ namespace FbxSharp
                     dstProp.ConnectSrcObject(fbxObjectsById[srcId]);
                     break;
                 default:
-                    throw new InvalidOperationException(string.Format("Unknown connection type. Expected 'OO' or 'OP'. Got '{0}' instead.", connType));
+                    throw new ConversionException(string.Format("Unknown connection type. Expected 'OO' or 'OP'. Got '{0}' instead.", connType));
                 }
             }
 
@@ -104,12 +104,12 @@ namespace FbxSharp
         void CheckDocuments(ParseObject docs)
         {
             if (docs.Properties[0].Name != "Count")
-                throw new NotImplementedException("Properties list does not start with 'Count'.");
+                throw new ConversionException("Properties list does not start with 'Count'.");
             if (docs.Properties[0].Values.Count < 1)
-                throw new NotImplementedException("Property 'Count' has no value.");
+                throw new ConversionException("Property 'Count' has no value.");
             var count = ((Number)docs.Properties[0].Values[0]).AsLong.Value;
             if (docs.Properties.Count != count + 1)
-                throw new NotImplementedException("Properties list Count does not match actual number of properties.");
+                throw new ConversionException("Properties list Count does not match actual number of properties.");
         }
 
         void CheckDocument(ParseObject doc)
@@ -119,19 +119,19 @@ namespace FbxSharp
         void CheckDefinitions(ParseObject defs)
         {
             if (defs.Properties[0].Name != "Version")
-                throw new NotImplementedException(string.Format("Properties list does not start with 'Version'. Got '{0}' instead.", defs.Properties[0].Name));
+                throw new ConversionException(string.Format("Properties list does not start with 'Version'. Got '{0}' instead.", defs.Properties[0].Name));
             if (defs.Properties[0].Values.Count < 1)
-                throw new NotImplementedException("Property 'Version' has no value.");
+                throw new ConversionException("Property 'Version' has no value.");
             var version = ((Number)defs.Properties[0].Values[0]).AsLong.Value;
 
             if (defs.Properties[1].Name != "Count")
-                throw new NotImplementedException("Properties list does not have a 'Count' in the second place.");
+                throw new ConversionException("Properties list does not have a 'Count' in the second place.");
             if (defs.Properties[1].Values.Count < 1)
-                throw new NotImplementedException("Property 'Count' has no value.");
+                throw new ConversionException("Property 'Count' has no value.");
             var count = ((Number)defs.Properties[1].Values[0]).AsLong.Value;
 
 //            if (defs.Properties.Count != count + 2)
-//                throw new NotImplementedException("Explicit count does not match actual number of properties.");
+//                throw new ConversionException("Explicit count does not match actual number of properties.");
         }
 
         Dictionary<string, Func<ParseObject, FbxObject>> ConvertersByObjectName =
@@ -178,7 +178,7 @@ namespace FbxSharp
                 return fbxobj;
             }
 
-            throw new InvalidOperationException(
+            throw new ConversionException(
                 string.Format(
                     "Unknown object type: {0}",
                     obj.Name));
@@ -211,7 +211,7 @@ namespace FbxSharp
                 return ConvertCamera(obj);
             }
 
-            throw new NotImplementedException(
+            throw new ConversionException(
                 string.Format(
                     "Unknown FBXNodeAttribute type: '{0}'.",
                     typeFlags));
@@ -229,7 +229,7 @@ namespace FbxSharp
                 foreach (var p in props70.Properties)
                 {
                     if (p.Name != "P") 
-                        throw new NotImplementedException(string.Format("Incorrect name for a property list: '{0}'.", p.Name));
+                        throw new ConversionException(string.Format("Incorrect name for a property list: '{0}'.", p.Name));
 
                     //P: "Size", "double", "Number", "",0.988142713904381
                     var propName = ((string)p.Values[0]);
@@ -243,7 +243,7 @@ namespace FbxSharp
                     }
                     else
                     {
-                        throw new NotImplementedException(string.Format("Unknown property type. Expected 'double'. Got '{0}' instead.", type1));
+                        throw new ConversionException(string.Format("Unknown property type. Expected 'double'. Got '{0}' instead.", type1));
                     }
 
                     switch (propName)
@@ -252,7 +252,7 @@ namespace FbxSharp
                         skeleton.Size.Value = (double)value;
                         break;
                     default:
-                        throw new NotImplementedException(string.Format("Unknown property name. Expected 'Size'. Got '{0}' instead.", propName));
+                        throw new ConversionException(string.Format("Unknown property name. Expected 'Size'. Got '{0}' instead.", propName));
                     }
                 }
             }
@@ -282,15 +282,15 @@ namespace FbxSharp
                     break;
                 case "TypeFlags":
                     if (((string)prop.Values[0]) != "Light")
-                        throw new NotImplementedException(string.Format("Unknown type in FbxLight. Expected 'Light'. Got '{0}' instead.", prop.Values[0]));
+                        throw new ConversionException(string.Format("Unknown type in FbxLight. Expected 'Light'. Got '{0}' instead.", prop.Values[0]));
                     break;
                 case "GeometryVersion":
                     var gversion = ((Number)prop.Values[0]).AsLong.Value;
                     if (gversion != 124)
-                        throw new NotImplementedException(string.Format("Unknown geometry version in FbxLight. Expected '124'. Got '{0}' instead.", gversion));
+                        throw new ConversionException(string.Format("Unknown geometry version in FbxLight. Expected '124'. Got '{0}' instead.", gversion));
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property name in FbxLight. Expected 'Properties70', 'TypeFlags', or 'GeometryVersion'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property name in FbxLight. Expected 'Properties70', 'TypeFlags', or 'GeometryVersion'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -319,11 +319,11 @@ namespace FbxSharp
                     break;
                 case "TypeFlags":
                     if (((string)prop.Values[0]) != "Camera")
-                        throw new NotImplementedException(string.Format("Incorrect type in FbxCamera. Expected 'Camera'. Got '{0}' instead.", (string)prop.Values[0]));
+                        throw new ConversionException(string.Format("Incorrect type in FbxCamera. Expected 'Camera'. Got '{0}' instead.", (string)prop.Values[0]));
                     break;
                 case "GeometryVersion":
                     if (((Number)prop.Values[0]).AsLong.Value != 124)
-                        throw new NotImplementedException(string.Format("Unknown geometry version in FbxCamera. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
+                        throw new ConversionException(string.Format("Unknown geometry version in FbxCamera. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
                     break;
                 case "Position":
                     position = new FbxVector3(
@@ -359,7 +359,7 @@ namespace FbxSharp
                     cameraOrthoZoom = ((Number)prop.Values[0]).AsDouble.Value;
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property name in FbxCamera. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property name in FbxCamera. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -375,7 +375,7 @@ namespace FbxSharp
             case "Mesh":
                 return ConvertMesh(obj);
             default:
-                throw new NotImplementedException(string.Format("Unknown geometry type in FbxGeometry. Expected 'Mesh'. Got '{0}' instead.", geometryType));
+                throw new ConversionException(string.Format("Unknown geometry type in FbxGeometry. Expected 'Mesh'. Got '{0}' instead.", geometryType));
             }
         }
 
@@ -416,7 +416,7 @@ namespace FbxSharp
                     break;
                 case "GeometryVersion":
                     if (((Number)prop.Values[0]).AsLong.Value != 124)
-                        throw new NotImplementedException(string.Format("Unknown geometry version in FbxMesh. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
+                        throw new ConversionException(string.Format("Unknown geometry version in FbxMesh. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
                     break;
                 case "LayerElementNormal":
                     index = (int)(prop.Values.Count > 0 ? ((Number)prop.Values[0]).AsLong.Value : 0);
@@ -443,7 +443,7 @@ namespace FbxSharp
                     ConvertLayer(layer, prop, normals, uvs, visibility, materials);
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property name in FbxMesh. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property name in FbxMesh. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -458,18 +458,18 @@ namespace FbxSharp
                 {
                 case "Version":
                     if (prop.Values.Count < 0)
-                        throw new NotImplementedException("No value for 'Version' in FbxLayer.");
+                        throw new ConversionException("No value for 'Version' in FbxLayer.");
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 100)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayer. Expected '100'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxLayer. Expected '100'. Got '{0}' instead.", version));
                     break;
                 case "LayerElement":
                     var type = prop.FindPropertyByName("Type");
                     if (type == null)
-                        throw new NotImplementedException("No Type found in FbxLayer.");
+                        throw new ConversionException("No Type found in FbxLayer.");
                     var index = prop.FindPropertyByName("TypedIndex");
                     if (index == null)
-                        throw new NotImplementedException("No TypedIndex found in FbxLayer.");
+                        throw new ConversionException("No TypedIndex found in FbxLayer.");
                     var indexValue = (int)((Number)index.Values[0]).AsLong.Value;
                     switch ((string)type.Values[0])
                     {
@@ -486,11 +486,11 @@ namespace FbxSharp
                         layer.SetUVs(uvs[indexValue]);
                         break;
                     default:
-                        throw new NotImplementedException(string.Format("Unknown LayerElement type in FbxLayer. Expected 'LayerElementNormal', 'LayerElementMaterial', 'LayerElementVisibility', or 'LayerElementUV'. Got '{0}' instead.", (string)type.Values[0]));
+                        throw new ConversionException(string.Format("Unknown LayerElement type in FbxLayer. Expected 'LayerElementNormal', 'LayerElementMaterial', 'LayerElementVisibility', or 'LayerElementUV'. Got '{0}' instead.", (string)type.Values[0]));
                     }
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxLayer. Expected 'Version' or 'LayerElement'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxLayer. Expected 'Version' or 'LayerElement'. Got '{0}' instead.", prop.Name));
                 }
             }
         }
@@ -506,7 +506,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayerElementNormal. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxLayerElementNormal. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     normals.SetName((string)prop.Values[0]);
@@ -525,7 +525,7 @@ namespace FbxSharp
                         .Select(v => v.ToVector4()));
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxLayerElementNormal. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Normals'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxLayerElementNormal. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Normals'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -543,7 +543,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayerElementUV. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxLayerElementUV. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     uvs.Name = ((string)prop.Values[0]);
@@ -566,7 +566,7 @@ namespace FbxSharp
                         .Select(n => (int)((Number)n).AsLong.Value));
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxLayerElementUV. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', 'UV', or 'UVIndex'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxLayerElementUV. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', 'UV', or 'UVIndex'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -584,7 +584,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayerElementVisibility. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxLayerElementVisibility. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     visibility.Name = ((string)prop.Values[0]);
@@ -599,7 +599,7 @@ namespace FbxSharp
                     visibility.GetDirectArray().List.AddRange(prop.Properties[0].Values.Select(n => (((Number)n).AsLong.Value == 1)));
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxLayerElementVisibility. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Visibility'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxLayerElementVisibility. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Visibility'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -617,7 +617,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxLayerElementMaterial. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxLayerElementMaterial. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     material.Name = ((string)prop.Values[0]);
@@ -633,7 +633,7 @@ namespace FbxSharp
                         prop.Properties[0].Values.Select(n => (int)((Number)n).AsLong.Value));
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxLayerElementMaterial. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Materials'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxLayerElementMaterial. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Materials'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -643,7 +643,7 @@ namespace FbxSharp
         public static FbxLayerElement.EMappingMode ConvertMappingInformationType(ParseObject obj)
         {
             if (obj.Values.Count < 1)
-                throw new NotImplementedException("Mapping mode has no value.");
+                throw new ConversionException("Mapping mode has no value.");
             switch ((string)obj.Values[0])
             {
             case "ByPolygonVertex":
@@ -657,14 +657,14 @@ namespace FbxSharp
             case "AllSame":
                 return FbxLayerElement.EMappingMode.AllSame;
             default:
-                throw new NotImplementedException(string.Format("Unknown mapping mode. Expected 'ByPolygonVertex', 'ByPolygon', 'ByVertex', 'ByEdge', or 'AllSame'. Got '{0}' instead.", (string)obj.Values[0]));
+                throw new ConversionException(string.Format("Unknown mapping mode. Expected 'ByPolygonVertex', 'ByPolygon', 'ByVertex', 'ByEdge', or 'AllSame'. Got '{0}' instead.", (string)obj.Values[0]));
             }
         }
 
         public static FbxLayerElement.EReferenceMode ConvertReferenceInformationType(ParseObject obj)
         {
             if (obj.Values.Count < 1)
-                throw new NotImplementedException("Reference mode has no value.");
+                throw new ConversionException("Reference mode has no value.");
             switch ((string)obj.Values[0])
             {
             case "Direct":
@@ -672,7 +672,7 @@ namespace FbxSharp
             case "IndexToDirect":
                 return FbxLayerElement.EReferenceMode.IndexToDirect;
             default:
-                throw new NotImplementedException(string.Format("Unknown reference mode. Expected 'Direct' or 'IndexToDirect'. Got '{0}' instead.", (string)obj.Values[0]));
+                throw new ConversionException(string.Format("Unknown reference mode. Expected 'Direct' or 'IndexToDirect'. Got '{0}' instead.", (string)obj.Values[0]));
             }
         }
 
@@ -683,7 +683,7 @@ namespace FbxSharp
             foreach (var p in props70.Properties)
             {
                 if (p.Name != "P")
-                    throw new NotImplementedException(string.Format("Incorrect property name. Expected 'P'. Got '{0}' instead.", p.Name));
+                    throw new ConversionException(string.Format("Incorrect property name. Expected 'P'. Got '{0}' instead.", p.Name));
 
                 // P: "Color", "ColorRGB", "Color", "",0.0313725490196078,0.0313725490196078,0.0313725490196078
                 var propName = ((string)p.Values[0]);
@@ -734,7 +734,7 @@ namespace FbxSharp
                     y = ((Number)p.Values[5]).AsDouble.Value;
                     z = ((Number)p.Values[6]).AsDouble.Value;
                     if (comment != "A+" && comment != "A")
-                        throw new NotImplementedException(string.Format("Invalid indicator for Lcl Scaling. Expected 'A' or 'A+'. Got '{0}' instead.", comment));
+                        throw new ConversionException(string.Format("Invalid indicator for Lcl Scaling. Expected 'A' or 'A+'. Got '{0}' instead.", comment));
                     propValue = new FbxVector3(x, y, z);
                     break;
                 case "KString":
@@ -758,12 +758,12 @@ namespace FbxSharp
                     break;
                 case "Number":
                     if (comment != "A")
-                        throw new NotImplementedException(string.Format("Invalid indicator for Number. Expected 'A'. Got '{0}' instead.", comment));
+                        throw new ConversionException(string.Format("Invalid indicator for Number. Expected 'A'. Got '{0}' instead.", comment));
                     propType = typeof(double);
                     propValue = ((Number)p.Values[4]).AsDouble.Value;
                     break;
                 default:
-                    throw new NotImplementedException("Unknown property type: " + type1);
+                    throw new ConversionException("Unknown property type: " + type1);
                 }
 
                 propNamesTypesValues.Add(
@@ -818,9 +818,9 @@ namespace FbxSharp
             var node = new FbxNode();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
             node.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -831,7 +831,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 232)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxNode. Expected '232'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxNode. Expected '232'. Got '{0}' instead.", version));
                     break;
                 case "Properties70":
                     ImportProperties(node, ConvertProperties70(prop));
@@ -849,7 +849,7 @@ namespace FbxSharp
                     node.Culling = (string)prop.Values[0];
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxNode. Expected 'Version', 'Properties70', 'MultiLayer', 'MultiTake', 'Shading', or 'Culling'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxNode. Expected 'Version', 'Properties70', 'MultiLayer', 'MultiTake', 'Shading', or 'Culling'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -887,9 +887,9 @@ namespace FbxSharp
             var pose = new FbxPose();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
             pose.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -906,13 +906,13 @@ namespace FbxSharp
                     }
                     else
                     {
-                        throw new NotImplementedException(string.Format("Unknown pose type. Expected 'BindPose'. Got '{0}' instead.", (string)prop.Values[0]));
+                        throw new ConversionException(string.Format("Unknown pose type. Expected 'BindPose'. Got '{0}' instead.", (string)prop.Values[0]));
                     }
                     break;
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 100)
-                        throw new NotImplementedException(string.Format("Unknown version. Expected 100. Got {0} instead.", version));
+                        throw new ConversionException(string.Format("Unknown version. Expected 100. Got {0} instead.", version));
                     break;
                 case "NbPoseNodes":
                     numPoseNodes = ((Number)prop.Values[0]).AsLong.Value;
@@ -922,12 +922,12 @@ namespace FbxSharp
                     pose.Add(posenode.Item1, posenode.Item2, posenode.Item3);
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxPose. Expected 'Type', 'Version', 'NbPoseNodes', or 'PoseNode'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxPose. Expected 'Type', 'Version', 'NbPoseNodes', or 'PoseNode'. Got '{0}' instead.", prop.Name));
                 }
             }
 
             if (numPoseNodes != pose.GetCount())
-                throw new InvalidOperationException(string.Format("The number of pose objects ({0}) does not match the value explicit given ({1}).", pose.GetCount(), numPoseNodes));
+                throw new ConversionException(string.Format("The number of pose objects ({0}) does not match the value explicit given ({1}).", pose.GetCount(), numPoseNodes));
 
             return pose;
         }
@@ -938,18 +938,18 @@ namespace FbxSharp
             Dictionary<ulong, ulong> actualIdsByInFileIds)
         {
             if (obj.Properties.Count != 2)
-                throw new NotImplementedException("Unknown properties in PoseNode.");
+                throw new ConversionException("Unknown properties in PoseNode.");
 
             var nodeIdProp = obj.FindPropertyByName("Node");
             if (nodeIdProp == null)
-                throw new InvalidOperationException("No node ID found in PoseNode.");
+                throw new ConversionException("No node ID found in PoseNode.");
             var inFileNodeId = (ulong)((Number)nodeIdProp.Values[0]).AsLong.Value;
             var nodeId = actualIdsByInFileIds[inFileNodeId];
             var node = (FbxNode)fbxObjectsById[(ulong)nodeId];
 
             var matrixProp = obj.FindPropertyByName("Matrix");
             if (matrixProp == null)
-                throw new InvalidOperationException("No matrix found in PoseNode.");
+                throw new ConversionException("No matrix found in PoseNode.");
             var matrix = ConvertMatrix(matrixProp);
 
             return new Tuple<FbxNode, FbxMatrix, bool>(node, matrix, false);
@@ -958,10 +958,10 @@ namespace FbxSharp
         public static FbxMatrix ConvertMatrix(ParseObject obj)
         {
             if (obj.Properties.Count != 1)
-                throw new InvalidOperationException("Unknown properties in FbxMatrix.");
+                throw new ConversionException("Unknown properties in FbxMatrix.");
             var values = obj.Properties[0].Values;
             if (values.Count != 16)
-                throw new InvalidOperationException(string.Format("Incorrect number of values for FbxMatrix. Expected 16. Got {0} instead.", values.Count));
+                throw new ConversionException(string.Format("Incorrect number of values for FbxMatrix. Expected 16. Got {0} instead.", values.Count));
 
             var v = values.Select(n => ((Number)n).AsDouble.Value).ToArray();
 
@@ -977,11 +977,11 @@ namespace FbxSharp
         {
             var shadingModelProp = obj.FindPropertyByName("ShadingModel");
             if (shadingModelProp == null)
-                throw new InvalidOperationException("No shading model found in FbxSurfaceMaterial.");
+                throw new ConversionException("No shading model found in FbxSurfaceMaterial.");
 
             var shadingModel = (string)shadingModelProp.Values[0];
             if (shadingModel != "phong")
-                throw new NotImplementedException(string.Format("Unknown shading model in FbxSurfaceMaterial. Expected 'phong'. Got '{0}' instead.", shadingModel));
+                throw new ConversionException(string.Format("Unknown shading model in FbxSurfaceMaterial. Expected 'phong'. Got '{0}' instead.", shadingModel));
 
             return ConvertPhongMaterial(obj);
         }
@@ -991,9 +991,9 @@ namespace FbxSharp
             var material = new FbxSurfacePhong();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
             material.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1004,7 +1004,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 102)
-                        throw new NotImplementedException(string.Format("Unknown version. Expected 102. Got {0} instead.", version));
+                        throw new ConversionException(string.Format("Unknown version. Expected 102. Got {0} instead.", version));
                     break;
                 case "ShadingModel":
                     break;
@@ -1016,7 +1016,7 @@ namespace FbxSharp
                     ImportProperties(material, ConvertProperties70(prop));
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxSurfacePhong.  Expected 'Version', 'ShadingModel', 'MultiLayer', or 'Properties70'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxSurfacePhong.  Expected 'Version', 'ShadingModel', 'MultiLayer', or 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1026,9 +1026,9 @@ namespace FbxSharp
         public static FbxObject ConvertDeformer(ParseObject obj)
         {
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in deformer. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in deformer. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for deformer. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for deformer. Expected 3. Got {0} instead.", obj.Values.Count));
             var type = ((string)obj.Values[2]);
 
             switch (type)
@@ -1038,7 +1038,7 @@ namespace FbxSharp
             case "Cluster":
                 return ConvertCluster(obj);
             default:
-                throw new NotImplementedException(string.Format("Unknown deformer type. Expected 'Skin' or 'Cluster'. Got '{0}' instead.", type));
+                throw new ConversionException(string.Format("Unknown deformer type. Expected 'Skin' or 'Cluster'. Got '{0}' instead.", type));
             }
         }
 
@@ -1047,9 +1047,9 @@ namespace FbxSharp
             var skin = new FbxSkin();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
             skin.Name = ((string)obj.Values[1]);
 
             foreach (var prop in obj.Properties)
@@ -1059,14 +1059,14 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxSkin. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxSkin. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Link_DeformAcuracy":  // TODO: double-check spelling
                     var accuracy = ((Number)prop.Values[0]).AsDouble.Value;
                     skin.DeformAccuracy = accuracy;
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxSkin. Expected 'Version' or 'Link_DeformAcuracy. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxSkin. Expected 'Version' or 'Link_DeformAcuracy. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1078,9 +1078,9 @@ namespace FbxSharp
             var cluster = new FbxCluster();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
             cluster.Name = ((string)obj.Values[1]);
 
             bool hasIndexes = false;
@@ -1095,7 +1095,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 100)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxSkin. Expected '100'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxSkin. Expected '100'. Got '{0}' instead.", version));
                     break;
                 case "UserData":
                     break;
@@ -1118,7 +1118,7 @@ namespace FbxSharp
                     hasTransformLink = true;
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxCluster. Expected 'Version', 'UserData', 'Indexes', 'Weights', 'Transform', or 'TransformLink'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxCluster. Expected 'Version', 'UserData', 'Indexes', 'Weights', 'Transform', or 'TransformLink'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1130,9 +1130,9 @@ namespace FbxSharp
             var video = new FbxVideo();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
             video.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1156,7 +1156,7 @@ namespace FbxSharp
                     video.RelativeFilename = (string)prop.Values[0];
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxVideo. Expected 'Type', 'Properties70', 'UseMipMap', 'Filename', or 'RelativeFilename'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxVideo. Expected 'Type', 'Properties70', 'UseMipMap', 'Filename', or 'RelativeFilename'. Got '{0}' instead.", prop.Name));
 
                 }
             }
@@ -1169,9 +1169,9 @@ namespace FbxSharp
             var texture = new FbxTexture();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
             texture.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1185,12 +1185,12 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 202)
-                        throw new NotImplementedException(string.Format("Unknown Version in FbxTexture. Expected '202'. Got '{0}' instead.", version));
+                        throw new ConversionException(string.Format("Unknown Version in FbxTexture. Expected '202'. Got '{0}' instead.", version));
                     break;
                 case "TextureName":
                     var name = (string)prop.Values[0];
                     if (name != texture.Name)
-                        throw new InvalidOperationException(string.Format("TextureName does not match. Expected '{0}'. Got '{1}' instead.", texture.Name, name));
+                        throw new ConversionException(string.Format("TextureName does not match. Expected '{0}'. Got '{1}' instead.", texture.Name, name));
                     break;
                 case "Properties70":
                     ImportProperties(texture, ConvertProperties70(prop));
@@ -1218,7 +1218,7 @@ namespace FbxSharp
                     texture.Cropping = ConvertVector4(prop.Values);
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxTexture: '{0}'.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxTexture: '{0}'.", prop.Name));
                 }
             }
 
@@ -1257,9 +1257,9 @@ namespace FbxSharp
             var animstack = new FbxAnimStack();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
             animstack.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1271,7 +1271,7 @@ namespace FbxSharp
                     ImportProperties(animstack, ConvertProperties70(prop));
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxAnimStack. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxAnimStack. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1283,14 +1283,14 @@ namespace FbxSharp
             var animlayer = new FbxAnimLayer();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
             animlayer.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
             if (obj.Properties.Count > 0)
-                throw new NotImplementedException("Expected property list to be empty.");
+                throw new ConversionException("Expected property list to be empty.");
 
             return animlayer;
         }
@@ -1300,9 +1300,9 @@ namespace FbxSharp
             var animCurveNode = new FbxAnimCurveNode();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
             animCurveNode.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1335,7 +1335,7 @@ namespace FbxSharp
                     }
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxAnimCurveNode. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxAnimCurveNode. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1347,9 +1347,9 @@ namespace FbxSharp
             var curve = new FbxAnimCurve();
 
             if (obj.Values.Count < 3)
-                throw new InvalidOperationException(string.Format("Not enough values in FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Not enough values in FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new NotImplementedException(string.Format("Too many values for FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(string.Format("Too many values for FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
             curve.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1369,7 +1369,7 @@ namespace FbxSharp
                 case "KeyVer":
                     long keyVersion = ((Number)prop.Values[0]).AsLong.Value;
                     if (keyVersion != 4008 && keyVersion != 4009)
-                        throw new NotImplementedException(string.Format("Unknown KeyVer. Expected 4008 or 4009. Got {0} instead.", keyVersion));
+                        throw new ConversionException(string.Format("Unknown KeyVer. Expected 4008 or 4009. Got {0} instead.", keyVersion));
                     break;
                 case "KeyTime":
                     keyTimes = prop.Properties[0].Values.Select(n => ((Number)n).AsLong.Value).ToArray();
@@ -1387,7 +1387,7 @@ namespace FbxSharp
                     attrRefCounts = prop.Properties[0].Values.Select(n => ((Number)n).AsLong.Value).ToArray();
                     break;
                 default:
-                    throw new NotImplementedException(string.Format("Unknown property in FbxAnimCurve. Expected 'Default', 'KeyVer', 'KeyTime', 'KeyValueFloat', 'KeyAttrFlags', 'KeyAttrDataFloat', or 'KeyAttrRefCount'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(string.Format("Unknown property in FbxAnimCurve. Expected 'Default', 'KeyVer', 'KeyTime', 'KeyValueFloat', 'KeyAttrFlags', 'KeyAttrDataFloat', or 'KeyAttrRefCount'. Got '{0}' instead.", prop.Name));
                 }
             }
 

--- a/Converter.cs
+++ b/Converter.cs
@@ -64,7 +64,7 @@ namespace FbxSharp
                     dstProp.ConnectSrcObject(fbxObjectsById[srcId]);
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown connection type. Expected 'OO' or 'OP'. Got '{0}' instead.", connType));
+                    throw new ConversionException(conn.Location, string.Format("Unknown connection type. Expected 'OO' or 'OP'. Got '{0}' instead.", connType));
                 }
             }
 
@@ -104,12 +104,12 @@ namespace FbxSharp
         void CheckDocuments(ParseObject docs)
         {
             if (docs.Properties[0].Name != "Count")
-                throw new ConversionException("Properties list does not start with 'Count'.");
+                throw new ConversionException(docs.Location, "Properties list does not start with 'Count'.");
             if (docs.Properties[0].Values.Count < 1)
-                throw new ConversionException("Property 'Count' has no value.");
+                throw new ConversionException(docs.Location, "Property 'Count' has no value.");
             var count = ((Number)docs.Properties[0].Values[0]).AsLong.Value;
             if (docs.Properties.Count != count + 1)
-                throw new ConversionException("Properties list Count does not match actual number of properties.");
+                throw new ConversionException(docs.Location, "Properties list Count does not match actual number of properties.");
         }
 
         void CheckDocument(ParseObject doc)
@@ -119,19 +119,19 @@ namespace FbxSharp
         void CheckDefinitions(ParseObject defs)
         {
             if (defs.Properties[0].Name != "Version")
-                throw new ConversionException(string.Format("Properties list does not start with 'Version'. Got '{0}' instead.", defs.Properties[0].Name));
+                throw new ConversionException(defs.Location, string.Format("Properties list does not start with 'Version'. Got '{0}' instead.", defs.Properties[0].Name));
             if (defs.Properties[0].Values.Count < 1)
-                throw new ConversionException("Property 'Version' has no value.");
+                throw new ConversionException(defs.Location, "Property 'Version' has no value.");
             var version = ((Number)defs.Properties[0].Values[0]).AsLong.Value;
 
             if (defs.Properties[1].Name != "Count")
-                throw new ConversionException("Properties list does not have a 'Count' in the second place.");
+                throw new ConversionException(defs.Location, "Properties list does not have a 'Count' in the second place.");
             if (defs.Properties[1].Values.Count < 1)
-                throw new ConversionException("Property 'Count' has no value.");
+                throw new ConversionException(defs.Location, "Property 'Count' has no value.");
             var count = ((Number)defs.Properties[1].Values[0]).AsLong.Value;
 
 //            if (defs.Properties.Count != count + 2)
-//                throw new ConversionException("Explicit count does not match actual number of properties.");
+//                throw new ConversionException(defs.Location, "Explicit count does not match actual number of properties.");
         }
 
         Dictionary<string, Func<ParseObject, FbxObject>> ConvertersByObjectName =
@@ -179,6 +179,7 @@ namespace FbxSharp
             }
 
             throw new ConversionException(
+                obj.Location,
                 string.Format(
                     "Unknown object type: {0}",
                     obj.Name));
@@ -212,6 +213,7 @@ namespace FbxSharp
             }
 
             throw new ConversionException(
+                obj.Location,
                 string.Format(
                     "Unknown FBXNodeAttribute type: '{0}'.",
                     typeFlags));
@@ -229,7 +231,7 @@ namespace FbxSharp
                 foreach (var p in props70.Properties)
                 {
                     if (p.Name != "P") 
-                        throw new ConversionException(string.Format("Incorrect name for a property list: '{0}'.", p.Name));
+                        throw new ConversionException(p.Location, string.Format("Incorrect name for a property list: '{0}'.", p.Name));
 
                     //P: "Size", "double", "Number", "",0.988142713904381
                     var propName = ((string)p.Values[0]);
@@ -243,7 +245,7 @@ namespace FbxSharp
                     }
                     else
                     {
-                        throw new ConversionException(string.Format("Unknown property type. Expected 'double'. Got '{0}' instead.", type1));
+                        throw new ConversionException(p.Location, string.Format("Unknown property type. Expected 'double'. Got '{0}' instead.", type1));
                     }
 
                     switch (propName)
@@ -252,7 +254,7 @@ namespace FbxSharp
                         skeleton.Size.Value = (double)value;
                         break;
                     default:
-                        throw new ConversionException(string.Format("Unknown property name. Expected 'Size'. Got '{0}' instead.", propName));
+                        throw new ConversionException(p.Location, string.Format("Unknown property name. Expected 'Size'. Got '{0}' instead.", propName));
                     }
                 }
             }
@@ -282,15 +284,15 @@ namespace FbxSharp
                     break;
                 case "TypeFlags":
                     if (((string)prop.Values[0]) != "Light")
-                        throw new ConversionException(string.Format("Unknown type in FbxLight. Expected 'Light'. Got '{0}' instead.", prop.Values[0]));
+                        throw new ConversionException(prop.Location, string.Format("Unknown type in FbxLight. Expected 'Light'. Got '{0}' instead.", prop.Values[0]));
                     break;
                 case "GeometryVersion":
                     var gversion = ((Number)prop.Values[0]).AsLong.Value;
                     if (gversion != 124)
-                        throw new ConversionException(string.Format("Unknown geometry version in FbxLight. Expected '124'. Got '{0}' instead.", gversion));
+                        throw new ConversionException(prop.Location, string.Format("Unknown geometry version in FbxLight. Expected '124'. Got '{0}' instead.", gversion));
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property name in FbxLight. Expected 'Properties70', 'TypeFlags', or 'GeometryVersion'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property name in FbxLight. Expected 'Properties70', 'TypeFlags', or 'GeometryVersion'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -319,11 +321,11 @@ namespace FbxSharp
                     break;
                 case "TypeFlags":
                     if (((string)prop.Values[0]) != "Camera")
-                        throw new ConversionException(string.Format("Incorrect type in FbxCamera. Expected 'Camera'. Got '{0}' instead.", (string)prop.Values[0]));
+                        throw new ConversionException(prop.Location, string.Format("Incorrect type in FbxCamera. Expected 'Camera'. Got '{0}' instead.", (string)prop.Values[0]));
                     break;
                 case "GeometryVersion":
                     if (((Number)prop.Values[0]).AsLong.Value != 124)
-                        throw new ConversionException(string.Format("Unknown geometry version in FbxCamera. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
+                        throw new ConversionException(prop.Location, string.Format("Unknown geometry version in FbxCamera. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
                     break;
                 case "Position":
                     position = new FbxVector3(
@@ -359,7 +361,7 @@ namespace FbxSharp
                     cameraOrthoZoom = ((Number)prop.Values[0]).AsDouble.Value;
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property name in FbxCamera. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property name in FbxCamera. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -375,7 +377,7 @@ namespace FbxSharp
             case "Mesh":
                 return ConvertMesh(obj);
             default:
-                throw new ConversionException(string.Format("Unknown geometry type in FbxGeometry. Expected 'Mesh'. Got '{0}' instead.", geometryType));
+                throw new ConversionException(obj.Location, string.Format("Unknown geometry type in FbxGeometry. Expected 'Mesh'. Got '{0}' instead.", geometryType));
             }
         }
 
@@ -416,7 +418,7 @@ namespace FbxSharp
                     break;
                 case "GeometryVersion":
                     if (((Number)prop.Values[0]).AsLong.Value != 124)
-                        throw new ConversionException(string.Format("Unknown geometry version in FbxMesh. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
+                        throw new ConversionException(prop.Location, string.Format("Unknown geometry version in FbxMesh. Expected '124'. Got '{0}' instead.", ((Number)prop.Values[0]).AsLong.Value));
                     break;
                 case "LayerElementNormal":
                     index = (int)(prop.Values.Count > 0 ? ((Number)prop.Values[0]).AsLong.Value : 0);
@@ -443,7 +445,7 @@ namespace FbxSharp
                     ConvertLayer(layer, prop, normals, uvs, visibility, materials);
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property name in FbxMesh. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property name in FbxMesh. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -458,18 +460,18 @@ namespace FbxSharp
                 {
                 case "Version":
                     if (prop.Values.Count < 0)
-                        throw new ConversionException("No value for 'Version' in FbxLayer.");
+                        throw new ConversionException(prop.Location, "No value for 'Version' in FbxLayer.");
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 100)
-                        throw new ConversionException(string.Format("Unknown Version in FbxLayer. Expected '100'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxLayer. Expected '100'. Got '{0}' instead.", version));
                     break;
                 case "LayerElement":
                     var type = prop.FindPropertyByName("Type");
                     if (type == null)
-                        throw new ConversionException("No Type found in FbxLayer.");
+                        throw new ConversionException(prop.Location, "No Type found in FbxLayer.");
                     var index = prop.FindPropertyByName("TypedIndex");
                     if (index == null)
-                        throw new ConversionException("No TypedIndex found in FbxLayer.");
+                        throw new ConversionException(prop.Location, "No TypedIndex found in FbxLayer.");
                     var indexValue = (int)((Number)index.Values[0]).AsLong.Value;
                     switch ((string)type.Values[0])
                     {
@@ -486,11 +488,11 @@ namespace FbxSharp
                         layer.SetUVs(uvs[indexValue]);
                         break;
                     default:
-                        throw new ConversionException(string.Format("Unknown LayerElement type in FbxLayer. Expected 'LayerElementNormal', 'LayerElementMaterial', 'LayerElementVisibility', or 'LayerElementUV'. Got '{0}' instead.", (string)type.Values[0]));
+                        throw new ConversionException(prop.Location, string.Format("Unknown LayerElement type in FbxLayer. Expected 'LayerElementNormal', 'LayerElementMaterial', 'LayerElementVisibility', or 'LayerElementUV'. Got '{0}' instead.", (string)type.Values[0]));
                     }
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxLayer. Expected 'Version' or 'LayerElement'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxLayer. Expected 'Version' or 'LayerElement'. Got '{0}' instead.", prop.Name));
                 }
             }
         }
@@ -506,7 +508,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new ConversionException(string.Format("Unknown Version in FbxLayerElementNormal. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxLayerElementNormal. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     normals.SetName((string)prop.Values[0]);
@@ -525,7 +527,7 @@ namespace FbxSharp
                         .Select(v => v.ToVector4()));
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxLayerElementNormal. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Normals'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxLayerElementNormal. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Normals'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -543,7 +545,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new ConversionException(string.Format("Unknown Version in FbxLayerElementUV. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxLayerElementUV. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     uvs.Name = ((string)prop.Values[0]);
@@ -566,7 +568,7 @@ namespace FbxSharp
                         .Select(n => (int)((Number)n).AsLong.Value));
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxLayerElementUV. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', 'UV', or 'UVIndex'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxLayerElementUV. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', 'UV', or 'UVIndex'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -584,7 +586,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new ConversionException(string.Format("Unknown Version in FbxLayerElementVisibility. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxLayerElementVisibility. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     visibility.Name = ((string)prop.Values[0]);
@@ -599,7 +601,7 @@ namespace FbxSharp
                     visibility.GetDirectArray().List.AddRange(prop.Properties[0].Values.Select(n => (((Number)n).AsLong.Value == 1)));
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxLayerElementVisibility. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Visibility'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxLayerElementVisibility. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Visibility'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -617,7 +619,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new ConversionException(string.Format("Unknown Version in FbxLayerElementMaterial. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxLayerElementMaterial. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Name":
                     material.Name = ((string)prop.Values[0]);
@@ -633,7 +635,7 @@ namespace FbxSharp
                         prop.Properties[0].Values.Select(n => (int)((Number)n).AsLong.Value));
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxLayerElementMaterial. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Materials'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxLayerElementMaterial. Expected 'Version', 'Name', 'MappingInformationType', 'ReferenceInformationType', or 'Materials'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -643,7 +645,7 @@ namespace FbxSharp
         public static FbxLayerElement.EMappingMode ConvertMappingInformationType(ParseObject obj)
         {
             if (obj.Values.Count < 1)
-                throw new ConversionException("Mapping mode has no value.");
+                throw new ConversionException(obj.Location, "Mapping mode has no value.");
             switch ((string)obj.Values[0])
             {
             case "ByPolygonVertex":
@@ -657,14 +659,14 @@ namespace FbxSharp
             case "AllSame":
                 return FbxLayerElement.EMappingMode.AllSame;
             default:
-                throw new ConversionException(string.Format("Unknown mapping mode. Expected 'ByPolygonVertex', 'ByPolygon', 'ByVertex', 'ByEdge', or 'AllSame'. Got '{0}' instead.", (string)obj.Values[0]));
+                throw new ConversionException(obj.Location, string.Format("Unknown mapping mode. Expected 'ByPolygonVertex', 'ByPolygon', 'ByVertex', 'ByEdge', or 'AllSame'. Got '{0}' instead.", (string)obj.Values[0]));
             }
         }
 
         public static FbxLayerElement.EReferenceMode ConvertReferenceInformationType(ParseObject obj)
         {
             if (obj.Values.Count < 1)
-                throw new ConversionException("Reference mode has no value.");
+                throw new ConversionException(obj.Location, "Reference mode has no value.");
             switch ((string)obj.Values[0])
             {
             case "Direct":
@@ -672,7 +674,7 @@ namespace FbxSharp
             case "IndexToDirect":
                 return FbxLayerElement.EReferenceMode.IndexToDirect;
             default:
-                throw new ConversionException(string.Format("Unknown reference mode. Expected 'Direct' or 'IndexToDirect'. Got '{0}' instead.", (string)obj.Values[0]));
+                throw new ConversionException(obj.Location, string.Format("Unknown reference mode. Expected 'Direct' or 'IndexToDirect'. Got '{0}' instead.", (string)obj.Values[0]));
             }
         }
 
@@ -683,7 +685,7 @@ namespace FbxSharp
             foreach (var p in props70.Properties)
             {
                 if (p.Name != "P")
-                    throw new ConversionException(string.Format("Incorrect property name. Expected 'P'. Got '{0}' instead.", p.Name));
+                    throw new ConversionException(p.Location, string.Format("Incorrect property name. Expected 'P'. Got '{0}' instead.", p.Name));
 
                 // P: "Color", "ColorRGB", "Color", "",0.0313725490196078,0.0313725490196078,0.0313725490196078
                 var propName = ((string)p.Values[0]);
@@ -734,7 +736,7 @@ namespace FbxSharp
                     y = ((Number)p.Values[5]).AsDouble.Value;
                     z = ((Number)p.Values[6]).AsDouble.Value;
                     if (comment != "A+" && comment != "A")
-                        throw new ConversionException(string.Format("Invalid indicator for Lcl Scaling. Expected 'A' or 'A+'. Got '{0}' instead.", comment));
+                        throw new ConversionException(p.Location, string.Format("Invalid indicator for Lcl Scaling. Expected 'A' or 'A+'. Got '{0}' instead.", comment));
                     propValue = new FbxVector3(x, y, z);
                     break;
                 case "KString":
@@ -758,12 +760,12 @@ namespace FbxSharp
                     break;
                 case "Number":
                     if (comment != "A")
-                        throw new ConversionException(string.Format("Invalid indicator for Number. Expected 'A'. Got '{0}' instead.", comment));
+                        throw new ConversionException(p.Location, string.Format("Invalid indicator for Number. Expected 'A'. Got '{0}' instead.", comment));
                     propType = typeof(double);
                     propValue = ((Number)p.Values[4]).AsDouble.Value;
                     break;
                 default:
-                    throw new ConversionException("Unknown property type: " + type1);
+                    throw new ConversionException(p.Location, "Unknown property type: " + type1);
                 }
 
                 propNamesTypesValues.Add(
@@ -818,9 +820,9 @@ namespace FbxSharp
             var node = new FbxNode();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxNode. Expected 3. Got {0} instead.", obj.Values.Count));
             node.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -831,7 +833,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 232)
-                        throw new ConversionException(string.Format("Unknown Version in FbxNode. Expected '232'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxNode. Expected '232'. Got '{0}' instead.", version));
                     break;
                 case "Properties70":
                     ImportProperties(node, ConvertProperties70(prop));
@@ -849,7 +851,7 @@ namespace FbxSharp
                     node.Culling = (string)prop.Values[0];
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxNode. Expected 'Version', 'Properties70', 'MultiLayer', 'MultiTake', 'Shading', or 'Culling'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxNode. Expected 'Version', 'Properties70', 'MultiLayer', 'MultiTake', 'Shading', or 'Culling'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -887,9 +889,9 @@ namespace FbxSharp
             var pose = new FbxPose();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxPose. Expected 3. Got {0} instead.", obj.Values.Count));
             pose.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -906,13 +908,13 @@ namespace FbxSharp
                     }
                     else
                     {
-                        throw new ConversionException(string.Format("Unknown pose type. Expected 'BindPose'. Got '{0}' instead.", (string)prop.Values[0]));
+                        throw new ConversionException(prop.Location, string.Format("Unknown pose type. Expected 'BindPose'. Got '{0}' instead.", (string)prop.Values[0]));
                     }
                     break;
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 100)
-                        throw new ConversionException(string.Format("Unknown version. Expected 100. Got {0} instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown version. Expected 100. Got {0} instead.", version));
                     break;
                 case "NbPoseNodes":
                     numPoseNodes = ((Number)prop.Values[0]).AsLong.Value;
@@ -922,12 +924,12 @@ namespace FbxSharp
                     pose.Add(posenode.Item1, posenode.Item2, posenode.Item3);
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxPose. Expected 'Type', 'Version', 'NbPoseNodes', or 'PoseNode'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxPose. Expected 'Type', 'Version', 'NbPoseNodes', or 'PoseNode'. Got '{0}' instead.", prop.Name));
                 }
             }
 
             if (numPoseNodes != pose.GetCount())
-                throw new ConversionException(string.Format("The number of pose objects ({0}) does not match the value explicit given ({1}).", pose.GetCount(), numPoseNodes));
+                throw new ConversionException(obj.Location, string.Format("The number of pose objects ({0}) does not match the value explicit given ({1}).", pose.GetCount(), numPoseNodes));
 
             return pose;
         }
@@ -938,18 +940,18 @@ namespace FbxSharp
             Dictionary<ulong, ulong> actualIdsByInFileIds)
         {
             if (obj.Properties.Count != 2)
-                throw new ConversionException("Unknown properties in PoseNode.");
+                throw new ConversionException(obj.Location, "Unknown properties in PoseNode.");
 
             var nodeIdProp = obj.FindPropertyByName("Node");
             if (nodeIdProp == null)
-                throw new ConversionException("No node ID found in PoseNode.");
+                throw new ConversionException(obj.Location, "No node ID found in PoseNode.");
             var inFileNodeId = (ulong)((Number)nodeIdProp.Values[0]).AsLong.Value;
             var nodeId = actualIdsByInFileIds[inFileNodeId];
             var node = (FbxNode)fbxObjectsById[(ulong)nodeId];
 
             var matrixProp = obj.FindPropertyByName("Matrix");
             if (matrixProp == null)
-                throw new ConversionException("No matrix found in PoseNode.");
+                throw new ConversionException(obj.Location, "No matrix found in PoseNode.");
             var matrix = ConvertMatrix(matrixProp);
 
             return new Tuple<FbxNode, FbxMatrix, bool>(node, matrix, false);
@@ -958,10 +960,10 @@ namespace FbxSharp
         public static FbxMatrix ConvertMatrix(ParseObject obj)
         {
             if (obj.Properties.Count != 1)
-                throw new ConversionException("Unknown properties in FbxMatrix.");
+                throw new ConversionException(obj.Location, "Unknown properties in FbxMatrix.");
             var values = obj.Properties[0].Values;
             if (values.Count != 16)
-                throw new ConversionException(string.Format("Incorrect number of values for FbxMatrix. Expected 16. Got {0} instead.", values.Count));
+                throw new ConversionException(obj.Location, string.Format("Incorrect number of values for FbxMatrix. Expected 16. Got {0} instead.", values.Count));
 
             var v = values.Select(n => ((Number)n).AsDouble.Value).ToArray();
 
@@ -977,11 +979,11 @@ namespace FbxSharp
         {
             var shadingModelProp = obj.FindPropertyByName("ShadingModel");
             if (shadingModelProp == null)
-                throw new ConversionException("No shading model found in FbxSurfaceMaterial.");
+                throw new ConversionException(obj.Location, "No shading model found in FbxSurfaceMaterial.");
 
             var shadingModel = (string)shadingModelProp.Values[0];
             if (shadingModel != "phong")
-                throw new ConversionException(string.Format("Unknown shading model in FbxSurfaceMaterial. Expected 'phong'. Got '{0}' instead.", shadingModel));
+                throw new ConversionException(shadingModelProp.Location, string.Format("Unknown shading model in FbxSurfaceMaterial. Expected 'phong'. Got '{0}' instead.", shadingModel));
 
             return ConvertPhongMaterial(obj);
         }
@@ -991,9 +993,9 @@ namespace FbxSharp
             var material = new FbxSurfacePhong();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxSurfacePhong. Expected 3. Got {0} instead.", obj.Values.Count));
             material.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1004,7 +1006,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 102)
-                        throw new ConversionException(string.Format("Unknown version. Expected 102. Got {0} instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown version. Expected 102. Got {0} instead.", version));
                     break;
                 case "ShadingModel":
                     break;
@@ -1016,7 +1018,7 @@ namespace FbxSharp
                     ImportProperties(material, ConvertProperties70(prop));
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxSurfacePhong.  Expected 'Version', 'ShadingModel', 'MultiLayer', or 'Properties70'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxSurfacePhong.  Expected 'Version', 'ShadingModel', 'MultiLayer', or 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1026,9 +1028,9 @@ namespace FbxSharp
         public static FbxObject ConvertDeformer(ParseObject obj)
         {
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in deformer. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in deformer. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for deformer. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for deformer. Expected 3. Got {0} instead.", obj.Values.Count));
             var type = ((string)obj.Values[2]);
 
             switch (type)
@@ -1038,7 +1040,7 @@ namespace FbxSharp
             case "Cluster":
                 return ConvertCluster(obj);
             default:
-                throw new ConversionException(string.Format("Unknown deformer type. Expected 'Skin' or 'Cluster'. Got '{0}' instead.", type));
+                throw new ConversionException(obj.Location, string.Format("Unknown deformer type. Expected 'Skin' or 'Cluster'. Got '{0}' instead.", type));
             }
         }
 
@@ -1047,9 +1049,9 @@ namespace FbxSharp
             var skin = new FbxSkin();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxSkin. Expected 3. Got {0} instead.", obj.Values.Count));
             skin.Name = ((string)obj.Values[1]);
 
             foreach (var prop in obj.Properties)
@@ -1059,14 +1061,14 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 101)
-                        throw new ConversionException(string.Format("Unknown Version in FbxSkin. Expected '101'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxSkin. Expected '101'. Got '{0}' instead.", version));
                     break;
                 case "Link_DeformAcuracy":  // TODO: double-check spelling
                     var accuracy = ((Number)prop.Values[0]).AsDouble.Value;
                     skin.DeformAccuracy = accuracy;
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxSkin. Expected 'Version' or 'Link_DeformAcuracy. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxSkin. Expected 'Version' or 'Link_DeformAcuracy. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1078,9 +1080,9 @@ namespace FbxSharp
             var cluster = new FbxCluster();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxCluster. Expected 3. Got {0} instead.", obj.Values.Count));
             cluster.Name = ((string)obj.Values[1]);
 
             bool hasIndexes = false;
@@ -1095,7 +1097,7 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 100)
-                        throw new ConversionException(string.Format("Unknown Version in FbxSkin. Expected '100'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxSkin. Expected '100'. Got '{0}' instead.", version));
                     break;
                 case "UserData":
                     break;
@@ -1118,7 +1120,7 @@ namespace FbxSharp
                     hasTransformLink = true;
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxCluster. Expected 'Version', 'UserData', 'Indexes', 'Weights', 'Transform', or 'TransformLink'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxCluster. Expected 'Version', 'UserData', 'Indexes', 'Weights', 'Transform', or 'TransformLink'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1130,9 +1132,9 @@ namespace FbxSharp
             var video = new FbxVideo();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxVideo. Expected 3. Got {0} instead.", obj.Values.Count));
             video.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1156,7 +1158,7 @@ namespace FbxSharp
                     video.RelativeFilename = (string)prop.Values[0];
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxVideo. Expected 'Type', 'Properties70', 'UseMipMap', 'Filename', or 'RelativeFilename'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxVideo. Expected 'Type', 'Properties70', 'UseMipMap', 'Filename', or 'RelativeFilename'. Got '{0}' instead.", prop.Name));
 
                 }
             }
@@ -1169,9 +1171,9 @@ namespace FbxSharp
             var texture = new FbxTexture();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxTexture. Expected 3. Got {0} instead.", obj.Values.Count));
             texture.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1185,12 +1187,12 @@ namespace FbxSharp
                 case "Version":
                     var version = ((Number)prop.Values[0]).AsLong.Value;
                     if (version != 202)
-                        throw new ConversionException(string.Format("Unknown Version in FbxTexture. Expected '202'. Got '{0}' instead.", version));
+                        throw new ConversionException(prop.Location, string.Format("Unknown Version in FbxTexture. Expected '202'. Got '{0}' instead.", version));
                     break;
                 case "TextureName":
                     var name = (string)prop.Values[0];
                     if (name != texture.Name)
-                        throw new ConversionException(string.Format("TextureName does not match. Expected '{0}'. Got '{1}' instead.", texture.Name, name));
+                        throw new ConversionException(prop.Location, string.Format("TextureName does not match. Expected '{0}'. Got '{1}' instead.", texture.Name, name));
                     break;
                 case "Properties70":
                     ImportProperties(texture, ConvertProperties70(prop));
@@ -1218,7 +1220,7 @@ namespace FbxSharp
                     texture.Cropping = ConvertVector4(prop.Values);
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxTexture: '{0}'.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxTexture: '{0}'.", prop.Name));
                 }
             }
 
@@ -1257,9 +1259,9 @@ namespace FbxSharp
             var animstack = new FbxAnimStack();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxAnimStack. Expected 3. Got {0} instead.", obj.Values.Count));
             animstack.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1271,7 +1273,7 @@ namespace FbxSharp
                     ImportProperties(animstack, ConvertProperties70(prop));
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxAnimStack. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxAnimStack. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1283,14 +1285,14 @@ namespace FbxSharp
             var animlayer = new FbxAnimLayer();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxAnimLayer. Expected 3. Got {0} instead.", obj.Values.Count));
             animlayer.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
             if (obj.Properties.Count > 0)
-                throw new ConversionException("Expected property list to be empty.");
+                throw new ConversionException(obj.Location, "Expected property list to be empty.");
 
             return animlayer;
         }
@@ -1300,9 +1302,9 @@ namespace FbxSharp
             var animCurveNode = new FbxAnimCurveNode();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxAnimCurveNode. Expected 3. Got {0} instead.", obj.Values.Count));
             animCurveNode.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1335,7 +1337,7 @@ namespace FbxSharp
                     }
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxAnimCurveNode. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxAnimCurveNode. Expected 'Properties70'. Got '{0}' instead.", prop.Name));
                 }
             }
 
@@ -1347,9 +1349,9 @@ namespace FbxSharp
             var curve = new FbxAnimCurve();
 
             if (obj.Values.Count < 3)
-                throw new ConversionException(string.Format("Not enough values in FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Not enough values in FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
             if (obj.Values.Count > 3)
-                throw new ConversionException(string.Format("Too many values for FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
+                throw new ConversionException(obj.Location, string.Format("Too many values for FbxAnimCurve. Expected 3. Got {0} instead.", obj.Values.Count));
             curve.Name = ((string)obj.Values[1]);
             var type = ((string)obj.Values[2]);
 
@@ -1369,7 +1371,7 @@ namespace FbxSharp
                 case "KeyVer":
                     long keyVersion = ((Number)prop.Values[0]).AsLong.Value;
                     if (keyVersion != 4008 && keyVersion != 4009)
-                        throw new ConversionException(string.Format("Unknown KeyVer. Expected 4008 or 4009. Got {0} instead.", keyVersion));
+                        throw new ConversionException(prop.Location, string.Format("Unknown KeyVer. Expected 4008 or 4009. Got {0} instead.", keyVersion));
                     break;
                 case "KeyTime":
                     keyTimes = prop.Properties[0].Values.Select(n => ((Number)n).AsLong.Value).ToArray();
@@ -1387,7 +1389,7 @@ namespace FbxSharp
                     attrRefCounts = prop.Properties[0].Values.Select(n => ((Number)n).AsLong.Value).ToArray();
                     break;
                 default:
-                    throw new ConversionException(string.Format("Unknown property in FbxAnimCurve. Expected 'Default', 'KeyVer', 'KeyTime', 'KeyValueFloat', 'KeyAttrFlags', 'KeyAttrDataFloat', or 'KeyAttrRefCount'. Got '{0}' instead.", prop.Name));
+                    throw new ConversionException(prop.Location, string.Format("Unknown property in FbxAnimCurve. Expected 'Default', 'KeyVer', 'KeyTime', 'KeyValueFloat', 'KeyAttrFlags', 'KeyAttrDataFloat', or 'KeyAttrRefCount'. Got '{0}' instead.", prop.Name));
                 }
             }
 

--- a/Converter.cs
+++ b/Converter.cs
@@ -16,11 +16,14 @@ namespace FbxSharp
             var scene = new FbxScene();
 
             var docs = parsed.FindPropertyByName("Documents");
-            CheckDocuments(docs);
-
-            foreach (var doc in docs.Properties.Skip(1))
+            if (docs != null)
             {
-                CheckDocument(doc);
+                CheckDocuments(docs);
+
+                foreach (var doc in docs.Properties.Skip(1))
+                {
+                    CheckDocument(doc);
+                }
             }
 
 

--- a/FbxPrint/Program.cs
+++ b/FbxPrint/Program.cs
@@ -3,6 +3,7 @@ using FbxSharp;
 using System.Text;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 
 namespace FbxPrint
 {
@@ -16,13 +17,81 @@ namespace FbxPrint
                 return;
             }
 
+            bool tokens = false;
+            bool parse = false;
             foreach (var filename in args)
             {
+                if (filename == "--tokens")
+                {
+                    tokens = true;
+                    continue;
+                }
+                if (filename == "--parse")
+                {
+                    parse = true;
+                    continue;
+                }
+
+                if (tokens)
+                {
+                    using (var reader = new StreamReader(filename))
+                    {
+                        var t = new Tokenizer(reader, filename: filename);
+                        var token = t.GetNextToken();
+                        while (token.HasValue)
+                        {
+                            var tt = token.Value;
+                            Console.WriteLine("\"{0}\", {1}, {2}", tt.Value, tt.Type, tt.Location);
+                            token = t.GetNextToken();
+                        }
+                    }
+                    continue;
+                }
+                if (parse)
+                {
+                    using (var reader = new StreamReader(filename))
+                    {
+                        var p = new Parser(new Tokenizer(reader, filename:filename));
+                        var objs = p.ReadFile();
+                        foreach (var obj in objs)
+                        {
+                            PrintParseObject(obj);
+                        }
+                    }
+                    continue;
+                }
                 var importer = new FbxImporter(filename);
                 var scene = importer.Import(filename);
 
                 var printer = new FbxSharp.ObjectPrinter();
                 printer.PrintObjectGraph(scene);
+            }
+        }
+        public static void PrintParseObject(ParseObject obj, string indent="")
+        {
+            if (obj == null)
+            {
+                Console.WriteLine("{0}null", indent);
+                return;
+            }
+            Console.WriteLine("{2}\"{0}\" {1}", obj.Name, obj.Location, indent);
+            Console.WriteLine("{0}Values:", indent);
+            foreach (var value in obj.Values)
+            {
+                Console.WriteLine("{1}{0}", value, indent);
+            }
+            if (obj.Properties == null)
+            {
+                Console.WriteLine("{0}Properties: null", indent);
+            }
+            else
+            {
+                Console.WriteLine("{0}Properties:", indent);
+                foreach (var prop in obj.Properties)
+                {
+                    PrintParseObject(prop, indent + "  ");
+                }
+                Console.WriteLine();
             }
         }
     }

--- a/FbxSharp.csproj
+++ b/FbxSharp.csproj
@@ -147,6 +147,7 @@
     <Compile Include="ObjectPrinter.Generated.cs" />
     <Compile Include="TokenizationException.cs" />
     <Compile Include="ParseException.cs" />
+    <Compile Include="ConversionException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/InputLocation.cs
+++ b/InputLocation.cs
@@ -16,6 +16,11 @@ namespace FbxSharp
         public readonly int Column;
         public readonly int Index;
 	public readonly string Filename;
+
+        public override string ToString()
+        {
+            return string.Format("{0}:{1},{2}", Filename, Line, Column);
+        }
     }
 }
 

--- a/ParseObject.cs
+++ b/ParseObject.cs
@@ -10,6 +10,7 @@ namespace FbxSharp
         public List<object> Values = new List<object>();
         public List<ParseObject> Properties = new List<ParseObject>();
         public bool HasEmptyBlock = true;
+        public InputLocation Location;
 
         public override string ToString()
         {

--- a/Parser.cs
+++ b/Parser.cs
@@ -52,7 +52,7 @@ namespace FbxSharp
             var values = new List<object>();
             bool hasEmptyBlock = false;
             List<ParseObject> subobjects = null;
-            var startLocation = tokenizer.CurrentLocation;
+            InputLocation startLocation = default(InputLocation);
 
             while (PeekNextToken().HasValue)
             {
@@ -70,6 +70,7 @@ namespace FbxSharp
                     break;
                 case ObjectState.Name:
                     token = GetNextToken().Value;
+                    startLocation = token.Location;
                     if (token.Type != TokenType.Name)
                         throw new ParseException(
                             token.Location,

--- a/Parser.cs
+++ b/Parser.cs
@@ -52,6 +52,7 @@ namespace FbxSharp
             var values = new List<object>();
             bool hasEmptyBlock = false;
             List<ParseObject> subobjects = null;
+            var startLocation = tokenizer.CurrentLocation;
 
             while (PeekNextToken().HasValue)
             {
@@ -195,6 +196,7 @@ namespace FbxSharp
                 Values = values,
                 Properties = subobjects,
                 HasEmptyBlock = hasEmptyBlock,
+                Location = startLocation,
             };
         }
 


### PR DESCRIPTION
This PR adds better exception messages to the `Converter` class, along with identifying the point in the fbx file where problems occurred.

This PR also adds options to the `FbxPrint` program to print out the results of tokenization and parsing, before converting objects.